### PR TITLE
Fix deprecation from ember-getowner-polyfill

### DIFF
--- a/addon/helpers/is-component.js
+++ b/addon/helpers/is-component.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 export function compute([name]) {
   name = (name || '').trim();
   if (!name) {
     return false;
   }
-  const owner = getOwner(this);
+  const owner = Ember.getOwner(this);
   const lookup = owner.lookup('component-lookup:main');
   if (!lookup.componentFor) {
     return !!lookup.lookupFactory(name);


### PR DESCRIPTION
The polyfill is now a true polyfill, meaning you can just use `Ember.getOwner` directly.